### PR TITLE
feat: bundle dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anchor-idl-filter",
   "version": "1.0.0",
-  "description": "CLI tool to filter Anchor IDL files by instruction, account, type, and more.",
+  "description": "CLI to filter, transform Anchor IDL (v0.30.0 or newer) files by instructions, accounts, types, events, and errors. Perfect for creating lightweight IDL files for specific use cases.",
   "bin": {
     "idl-filter": "./dist/index.js"
   },
@@ -32,6 +32,9 @@
   "author": "wobondar",
   "license": "MIT",
   "packageManager": "pnpm@10.11.1",
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "dist",
     "src"
@@ -40,7 +43,6 @@
     "access": "public"
   },
   "dependencies": {
-    "camelcase": "^8.0.0",
     "commander": "^14.0.0"
   },
   "devDependencies": {
@@ -49,6 +51,7 @@
     "@types/eslint": "^9.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.29",
+    "camelcase": "^8.0.0",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      camelcase:
-        specifier: ^8.0.0
-        version: 8.0.0
       commander:
         specifier: ^14.0.0
         version: 14.0.0
@@ -30,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.15.29
         version: 22.15.29
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       eslint:
         specifier: ^9.28.0
         version: 9.28.0

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   external: ["commander"],
+  noExternal: ["camelcase"],
   format: ["esm"],
   target: "node20",
   outDir: "dist",


### PR DESCRIPTION
Ensures `camelcase` is bundled by marking it as non-external.